### PR TITLE
06.05 Add Reports page

### DIFF
--- a/right-for-life_front/src/App.jsx
+++ b/right-for-life_front/src/App.jsx
@@ -20,6 +20,8 @@ import { EmergencyHelpPage } from "./containers/EmergencyHelpPage"
 import { SingleEmergencyHelpPage } from "./containers/SingleEmergencyHelpPage"
 import { ScrollToTop } from "./components/ScrollToTop";
 import { LoginPage } from "./containers/LoginPage";
+import {ReportsPage} from "./containers/ReportsPage";
+import {ReportPage} from "./containers/ReportPage/ReportPage";
 
 function App({store}) {
   return (
@@ -34,6 +36,8 @@ function App({store}) {
             <Route exact path="/animals/:id" component={AnimalDetailsPage}/>
             <Route exact path="/news" component={NewsListPage}/>
             <Route exact path="/news/:id" component={NewsPage}/>
+            <Route exact path="/reports" component={ReportsPage}/>
+            <Route exact path="/reports/:id" component={ReportPage}/>
             <Route exact path="/stories" component={HappyStoriesPage}/>
             <Route exact path="/stories/:id" component={HappyStoryPage}/>
             <Route exact path="/help" component={DonatePage}/>

--- a/right-for-life_front/src/components/ArticleItem/ArticleItem.jsx
+++ b/right-for-life_front/src/components/ArticleItem/ArticleItem.jsx
@@ -11,11 +11,11 @@ export const ArticleItem = ({article}) => {
           className="h-64 rounded-xl bg-cover shadow-md bg-center"
           style={{backgroundImage: "url(" + photo + ")"}}
         />
-      <div className="z-40 w-19/20 bg-white text-lightgray-700 shadow-xl rounded-xl self-center -mt-10 px-5
-                      pt-5 overflow-hidden relative xl:h-56">
+      <div className={`z-40 w-19/20 bg-white text-lightgray-700 shadow-xl rounded-xl self-center -mt-10 px-5
+                      pt-5 pb-20 overflow-hidden relative  ${text?.length > 0 ? 'xl:h-56' : ''}`}>
         <p className="font-medium mb-2">{new Date(Number(date)).toLocaleDateString()}</p>
         <h2 className="uppercase mb-2 font-bold">{title.slice(0, 80)}{title.length >= 80 ? '...' : ''}</h2>
-        <p className="mt-b font-size-sm">{text.slice(0, 120)}...</p>
+        {text?.length > 0 ? <p className="mt-b font-size-sm">{text.slice(0, 120)}...</p> : ''}
           <Link
             to={`${currentURL}/${_id}`}
             className="min-w-5/12 bg-orange-300 hover:bg-orange-400 text-orange-700 font-bold py-3 px-2

--- a/right-for-life_front/src/components/Footer/Footer.jsx
+++ b/right-for-life_front/src/components/Footer/Footer.jsx
@@ -31,6 +31,14 @@ export const Footer = () => {
 			</ul>
 			<span className="mx-24">Developed by group DP-180 Web-UI SoftServe Inc.</span>
 			<NavLink
+				className="mx-4 cursor-pointer text-gray-600 hover:text-gray-700"
+				exact
+				to="/reports"
+				activeClassName="text-gray-700"
+			>
+				Отчеты
+			</NavLink>
+			<NavLink
 				className="mx-4 cursor-pointer text-red-600 hover:text-red-700 select-none"
 				exact
 				to="/"

--- a/right-for-life_front/src/containers/ReportPage/ReportPage.jsx
+++ b/right-for-life_front/src/containers/ReportPage/ReportPage.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import {Link, useParams} from "react-router-dom";
+import {API} from "../../rootConstants";
+import {withFetchDataIndicators} from "../../hoc/withFetchDataIndicators";
+import {ErrorIndicator} from "../../components/ErrorIndicator";
+import {ArticleImageGallery} from "../../components/ArticleImageGallery";
+import {BackBtn} from "../../components/FloatingBtn";
+
+const ReportPage = ({data}) => {
+  let {id} = useParams();
+  const article = data.find(article => article._id === Number(id));
+
+  if (!article)
+    return (
+      <ErrorIndicator
+        message="Страница не найдена :("
+        renderAction={() => <Link to="/reports">Вернуться к списку отчетов</Link>}
+      />
+    );
+
+  return (
+    <div>
+      <div className="max-w-4xl mx-auto mb-20">
+        <h1 className="my-6 font-bold text-lightgray-700 text-4xl uppercase">{article.title}</h1>
+        <BackBtn />
+        <ArticleImageGallery images={article.gallery}/>
+      </div>
+    </div>
+  );
+};
+
+const wrappedComponent = withFetchDataIndicators(
+  ReportPage,
+  API.REPORTS,
+);
+
+export {wrappedComponent as ReportPage};

--- a/right-for-life_front/src/containers/ReportPage/index.js
+++ b/right-for-life_front/src/containers/ReportPage/index.js
@@ -1,0 +1,1 @@
+export { ReportPage } from './ReportPage';

--- a/right-for-life_front/src/containers/ReportsPage/ReportsPage.jsx
+++ b/right-for-life_front/src/containers/ReportsPage/ReportsPage.jsx
@@ -1,0 +1,21 @@
+import React from "react";
+import {API} from "../../rootConstants";
+import {withPagination} from "../../hoc/withPagination";
+import {withFetchDataIndicators} from "../../hoc/withFetchDataIndicators";
+import {ArticlesList} from "../../components/ArticlesList";
+
+const ReportsPage = ({data}) => {
+  data.forEach(item => item.photo = item.gallery[0]);
+  return (
+    <div>
+      <ArticlesList articles={data} listTitle="Финансовые отчеты"/>
+    </div>
+  );
+};
+
+const wrappedComponent = withFetchDataIndicators(
+  withPagination(ReportsPage, 10),
+  API.REPORTS,
+);
+
+export {wrappedComponent as ReportsPage};

--- a/right-for-life_front/src/containers/ReportsPage/index.js
+++ b/right-for-life_front/src/containers/ReportsPage/index.js
@@ -1,0 +1,1 @@
+export { ReportsPage } from './ReportsPage';

--- a/right-for-life_front/src/rootConstants.js
+++ b/right-for-life_front/src/rootConstants.js
@@ -28,5 +28,9 @@ export const API = Object.freeze({
   EMERGENCY_HELP: {
     name: 'EMERGENCY_HELP',
     api: `${BE_URL}/emergency`,
-  }, 
+  },
+  REPORTS: {
+    name: 'REPORTS',
+    api: 'https://raw.githubusercontent.com/protonaby/demo3-animal-shelter/master/db/reports_common.json',
+  },
 });


### PR DESCRIPTION
 - Add Reports page with reports grpuped by month
 - Add Report page with gallery of all documents for a month (reuse `ArticleImageGallery` component)
 - Add Reports link to the Footer
 - Update `ArticleItem` component to display better when article doesn't contain any text

![Reports page](https://user-images.githubusercontent.com/58205310/73823261-895d1480-4800-11ea-9ef4-d0cba915c8c0.jpg)


![Report page](https://user-images.githubusercontent.com/58205310/73823265-8bbf6e80-4800-11ea-8cd1-fd0d958335f5.jpg)
