### PR TITLE
09.13 Reusable component "edit mode bar"

### DIFF
--- a/right-for-life_front/src/components/Article/Article.jsx
+++ b/right-for-life_front/src/components/Article/Article.jsx
@@ -9,6 +9,7 @@ import { EditArticleFeaturedImage } from '../EditArticleFeaturedImage';
 import { EditVideosList } from "../EditVideosList";
 import { UpdateImageGallery } from '../UpdateImageGallery';
 import { extractVideoIdFromYouTubeLink } from "../../helpers/extractVideoIdFromYouTubeLink";
+import { EditModeBar } from '../EditModeBar';
 
 import './style.css';
 
@@ -26,12 +27,10 @@ export const Article = ({article}) => {
       <BackBtn position="left-0 ml-2 mt-6"/>
       <ShareBtn position="right-0 mr-2 mt-6"/>
 
-      <button onClick={() => {
-        setIsEdit(!isEdit);
-        console.log(state);
-      }}>
-        EDIT
-      </button>
+      <EditModeBar  
+        onEdit={() => setIsEdit(!isEdit)}
+        state={state}
+      />
 
       {isEdit
         ? <EditArticleFeaturedImage 

--- a/right-for-life_front/src/components/EditModeBar/EditModeBar.jsx
+++ b/right-for-life_front/src/components/EditModeBar/EditModeBar.jsx
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+
+export const EditModeBar = ({ state, onEdit }) => {
+  const [open, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button 
+        className={`fixed right-0 bottom-0 flex items-center justify-center h-14 w-14 m-10 rounded-full font-bold text-green-800 bg-green-200 ${!open ? 'visible' : 'invisible'}`}
+        onClick={() => {
+          setIsOpen(true);
+          onEdit();
+        }}>
+        <i className="fas fa-pen text-xl" />
+      </button>
+      <article className={`fixed z-50 inset-x-0 bottom-0 flex justify-center py-2 text-sm shadow-xl bg-green-200 ${open ? 'visible' : 'invisible'}`}>
+        <section>
+          <button 
+            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 uppercase"
+            onClick={() => {
+              onEdit();
+            }}>
+            Предпросмотр
+          </button>
+        </section>
+        <section>
+          <button 
+            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 uppercase"
+            onClick={() => {
+              setIsOpen(false);
+              onEdit();
+              console.log(state);
+            }}>
+            Сохранить
+          </button>
+          <button 
+            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 uppercase"
+            onClick={() => {
+              window.location.reload();
+            }}>
+            Отменить
+          </button>
+        </section>
+      </article>
+    </>
+  );
+};

--- a/right-for-life_front/src/components/EditModeBar/EditModeBar.jsx
+++ b/right-for-life_front/src/components/EditModeBar/EditModeBar.jsx
@@ -2,11 +2,12 @@ import React, { useState } from 'react';
 
 export const EditModeBar = ({ state, onEdit }) => {
   const [open, setIsOpen] = useState(false);
+  const [isEdit, setIsEdit] = useState(true); 
 
   return (
     <>
       <button 
-        className={`fixed right-0 bottom-0 flex items-center justify-center h-14 w-14 m-10 rounded-full font-bold text-green-800 bg-green-200 ${!open ? 'visible' : 'invisible'}`}
+        className={`fixed right-0 bottom-0 flex items-center justify-center h-14 w-14 m-12 rounded-full font-bold shadow-xl text-lightgray-700 bg-white ${!open ? 'visible' : 'invisible'}`}
         onClick={() => {
           setIsOpen(true);
           onEdit();
@@ -16,16 +17,17 @@ export const EditModeBar = ({ state, onEdit }) => {
       <article className={`fixed z-50 inset-x-0 bottom-0 flex justify-center py-2 text-sm shadow-xl bg-green-200 ${open ? 'visible' : 'invisible'}`}>
         <section>
           <button 
-            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 uppercase"
+            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 hover:bg-green-400 uppercase"
             onClick={() => {
+              setIsEdit(!isEdit);
               onEdit();
             }}>
-            Предпросмотр
+            {isEdit ? 'Предпросмотр' : 'Редактировать'}
           </button>
         </section>
         <section>
           <button 
-            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 uppercase"
+            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 hover:bg-green-400 uppercase"
             onClick={() => {
               setIsOpen(false);
               onEdit();
@@ -34,7 +36,7 @@ export const EditModeBar = ({ state, onEdit }) => {
             Сохранить
           </button>
           <button 
-            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 uppercase"
+            className="mx-2 px-4 py-2 rounded-lg font-bold text-green-800 bg-green-300 hover:bg-green-400 uppercase"
             onClick={() => {
               window.location.reload();
             }}>

--- a/right-for-life_front/src/components/EditModeBar/index.js
+++ b/right-for-life_front/src/components/EditModeBar/index.js
@@ -1,0 +1,1 @@
+export { EditModeBar } from './EditModeBar';


### PR DESCRIPTION
The button will be displayed after user authorization:

<img width="100%" alt="1" src="https://user-images.githubusercontent.com/51407533/74468967-6982bc00-4ea4-11ea-9993-44d723df7297.PNG">

After clicking on the button, the editing mode will open:

<img width="100%" alt="2" src="https://user-images.githubusercontent.com/51407533/74468959-67206200-4ea4-11ea-865a-3a50daa51d4d.PNG">

At the moment, button "save" displays the modified data object in the console.